### PR TITLE
Merge in NIRI datafinder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           conda run -n dragons pip install .
           conda run -n dragons niriPipe test downloader
+          conda run -n dragons niriPipe test finder
 
   deploy_container:
     runs-on: ubuntu-latest
@@ -118,3 +119,7 @@ jobs:
       - name: Container integration test of downloader.
         run: |
           conda run -n dragons niriPipe test downloader
+
+      - name: Container integration test of data finder.
+        run: |
+          conda run -n dragons niriPipe test finder

--- a/niriPipe/inttests.py
+++ b/niriPipe/inttests.py
@@ -64,13 +64,12 @@
 #
 #
 # ***********************************************************************
-from astroquery.cadc import Cadc
 import os
 import logging
 import hashlib
 from pathlib import Path
 import niriPipe.utils.downloader
-import niriPipe.utils.finder
+from niriPipe.utils.finder import Finder
 
 
 def create_logger():
@@ -122,11 +121,7 @@ def downloader_inttest():
         "AND proposal_id = 'GN-2019A-FT-108'"
 
     try:
-        cadc = Cadc()
-        job = cadc.create_async(query)
-        job.run().wait()
-        job.raise_if_error()
-        table = job.fetch_result().to_table()
+        table = Finder._do_query(query)
     except Exception:
         logging.exception("Problem getting table from CADC.")
 
@@ -191,7 +186,7 @@ def finder_inttest():
     module_logger.info("Starting finder inttest with stack {}".format(
         state['current_stack']['obs_name']))
 
-    CADC_data_finder = niriPipe.utils.finder.Finder(state=state)
+    CADC_data_finder = Finder(state=state)
     table = CADC_data_finder.run()
     table.sort(['productID'])
 
@@ -214,8 +209,7 @@ def finder_inttest():
     desired_frames.sort()
 
     for frame in desired_frames:
-        if frame not in table['productID']:
-            raise RuntimeError("Frame {} not found.".format(frame))
+        assert frame in table['productID'], "Frame {} not found.".format(frame)
 
     module_logger.info(
         "Test for stack GN-2019A-FT-108-12 succeeded. " +
@@ -263,16 +257,14 @@ def finder_inttest():
     module_logger.info("Starting finder inttest with stack {}".format(
         state['current_stack']['obs_name']))
 
-    CADC_data_finder = niriPipe.utils.finder.Finder(state=state)
+    CADC_data_finder = Finder(state=state)
     table = CADC_data_finder.run()
-    table.sort(['productID'])
 
     module_logger.debug("Resulting table:")
     module_logger.debug('\n'+'\n'.join(table.pformat_all()))
 
     for frame in desired_frames:
-        if frame not in table['productID']:
-            raise RuntimeError("Frame {} not found.".format(frame))
+        assert frame in table['productID'], "Frame {} not found.".format(frame)
 
     module_logger.info(
         "Test for stack GN-2007B-Q-85-24 succeeded. " +

--- a/niriPipe/inttests.py
+++ b/niriPipe/inttests.py
@@ -70,6 +70,7 @@ import logging
 import hashlib
 from pathlib import Path
 import niriPipe.utils.downloader
+import niriPipe.utils.finder
 
 
 def create_logger():
@@ -155,4 +156,124 @@ def downloader_inttest():
     else:
         raise RuntimeError(
             "Hash of downloads '{}' is different ".format(out_hash) +
-            "than the expected value of '{}'.".format(expected_hash))
+            "than the expected value of '0d6ae285dcdb60904561aca79618afef'.")
+
+
+def finder_inttest():
+    """
+    Make sure the Finder class can find NIRI data.
+    """
+
+    """
+    First test: find data for stack GN-2019A-FT-108-12.
+
+    Stack name:  GN-2019A-FT-108-12
+    Object:      N20190405S01[11-37]
+    Flats:       N20190406S00[07-26]
+    Shortdark:   N20190406S01[12-21]
+    Longdarks:   N20190406S00[42-56]
+    """
+
+    state = {
+        'config': {
+            'DATAFINDER': {
+                'min_objects': 1,
+                'min_flats': 1,
+                'min_longdarks': 1,
+                'min_shortdarks': 0
+            }
+        },
+        'current_stack': {
+            'obs_name': 'GN-2019A-FT-108-12'
+        }
+    }
+
+    module_logger.info("Starting finder inttest with stack {}".format(
+        state['current_stack']['obs_name']))
+
+    CADC_data_finder = niriPipe.utils.finder.Finder(state=state)
+    table = CADC_data_finder.run()
+    table.sort(['productID'])
+
+    module_logger.debug("Resulting table:")
+    module_logger.debug('\n'+'\n'.join(table.pformat_all()))
+
+    # Object frames
+    desired_frames = \
+        ['N20190405S01'+str(x) for x in range(11, 38)]
+    # Flats
+    desired_frames.extend(
+        ['N20190406S00'+'{:02d}'.format(x) for x in range(7, 27)])
+    # Short darks
+    desired_frames.extend(
+        ['N20190406S01'+'{:02d}'.format(x) for x in range(12, 22)])
+    # Long darks
+    desired_frames.extend(
+        ['N20190406S00'+'{:02d}'.format(x) for x in range(42, 57)])
+
+    desired_frames.sort()
+
+    for frame in desired_frames:
+        if frame not in table['productID']:
+            raise RuntimeError("Frame {} not found.".format(frame))
+
+    module_logger.info(
+        "Test for stack GN-2019A-FT-108-12 succeeded. " +
+        "Desired {} frames, found {}.".format(len(desired_frames), len(table)))
+
+    """
+    Another test: get a stack and associated calibrations from
+    Tim Davidge's program.
+
+    Stack name:     GN-2007B-Q-85-24
+    Object:         N20080120S01[02-31]
+    Flats:          N20080120S03[24-32], N20080120S03[34-42]
+    Longdarks:      N20080121S03[83-94]
+    Shortdarks:     N20080119S00[16-25]
+    """
+
+    desired_frames = ['N20080120S01{:02d}'.format(x) for x in range(2, 32)]
+    desired_frames.extend(
+        ['N20080121S0{:03d}'.format(x) for x in range(77, 138)])
+    desired_frames.extend(
+        ['N20080120S03{:02d}'.format(x) for x in range(24, 33)])
+    desired_frames.extend(
+        ['N20080120S03{:02d}'.format(x) for x in range(34, 43)])
+    desired_frames.extend(
+        ['N20080121S03{:02d}'.format(x) for x in range(83, 95)])
+    desired_frames.extend(
+        ['N20080119S00{:02d}'.format(x) for x in range(16, 26)])
+
+    desired_frames.sort()
+
+    state = {
+        'config': {
+            'DATAFINDER': {
+                'min_objects': 1,
+                'min_flats': 1,
+                'min_longdarks': 1,
+                'min_shortdarks': 0
+            }
+        },
+        'current_stack': {
+            'obs_name': 'GN-2007B-Q-85-24'
+        }
+    }
+
+    module_logger.info("Starting finder inttest with stack {}".format(
+        state['current_stack']['obs_name']))
+
+    CADC_data_finder = niriPipe.utils.finder.Finder(state=state)
+    table = CADC_data_finder.run()
+    table.sort(['productID'])
+
+    module_logger.debug("Resulting table:")
+    module_logger.debug('\n'+'\n'.join(table.pformat_all()))
+
+    for frame in desired_frames:
+        if frame not in table['productID']:
+            raise RuntimeError("Frame {} not found.".format(frame))
+
+    module_logger.info(
+        "Test for stack GN-2007B-Q-85-24 succeeded. " +
+        "Desired {} frames, found {}.".format(len(desired_frames), len(table)))

--- a/niriPipe/niriReduce.py
+++ b/niriPipe/niriReduce.py
@@ -25,12 +25,14 @@ def niri_reduce_main():
 
     parser_test = subparsers.add_parser('test')
     parser_test.add_argument('testName', metavar='TESTNAME', type=str, nargs=1,
-                             choices=['downloader'],
+                             choices=['downloader', 'finder'],
                              help='Str name of test to run.')
 
     args = parser.parse_args()
     if hasattr(args, 'testName'):
         if 'downloader' in args.testName:
             niriPipe.inttests.downloader_inttest()
+        elif 'finder' in args.testName:
+            niriPipe.inttests.finder_inttest()
     else:
         parser.print_help()

--- a/niriPipe/utils/finder.py
+++ b/niriPipe/utils/finder.py
@@ -1,0 +1,396 @@
+# -*- coding: utf-8 -*-
+# ***********************************************************************
+# ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+# *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+#
+#  (c) 2021.                            (c) 2021.
+#  Government of Canada                 Gouvernement du Canada
+#  National Research Council            Conseil national de recherches
+#  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+#  All rights reserved                  Tous droits réservés
+#
+#  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+#  expressed, implied, or               énoncée, implicite ou légale,
+#  statutory, of any kind with          de quelque nature que ce
+#  respect to the software,             soit, concernant le logiciel,
+#  including without limitation         y compris sans restriction
+#  any warranty of merchantability      toute garantie de valeur
+#  or fitness for a particular          marchande ou de pertinence
+#  purpose. NRC shall not be            pour un usage particulier.
+#  liable in any event for any          Le CNRC ne pourra en aucun cas
+#  damages, whether direct or           être tenu responsable de tout
+#  indirect, special or general,        dommage, direct ou indirect,
+#  consequential or incidental,         particulier ou général,
+#  arising from the use of the          accessoire ou fortuit, résultant
+#  software.  Neither the name          de l'utilisation du logiciel. Ni
+#  of the National Research             le nom du Conseil National de
+#  Council of Canada nor the            Recherches du Canada ni les noms
+#  names of its contributors may        de ses  participants ne peuvent
+#  be used to endorse or promote        être utilisés pour approuver ou
+#  products derived from this           promouvoir les produits dérivés
+#  software without specific prior      de ce logiciel sans autorisation
+#  written permission.                  préalable et particulière
+#                                       par écrit.
+#
+#  This file is part of the             Ce fichier fait partie du projet
+#  OpenCADC project.                    OpenCADC.
+#
+#  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+#  you can redistribute it and/or       vous pouvez le redistribuer ou le
+#  modify it under the terms of         modifier suivant les termes de
+#  the GNU Affero General Public        la “GNU Affero General Public
+#  License as published by the          License” telle que publiée
+#  Free Software Foundation,            par la Free Software Foundation
+#  either version 3 of the              : soit la version 3 de cette
+#  License, or (at your option)         licence, soit (à votre gré)
+#  any later version.                   toute version ultérieure.
+#
+#  OpenCADC is distributed in the       OpenCADC est distribué
+#  hope that it will be useful,         dans l’espoir qu’il vous
+#  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+#  without even the implied             GARANTIE : sans même la garantie
+#  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+#  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+#  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+#  General Public License for           Générale Publique GNU Affero
+#  more details.                        pour plus de détails.
+#
+#  You should have received             Vous devriez avoir reçu une
+#  a copy of the GNU Affero             copie de la Licence Générale
+#  General Public License along         Publique GNU Affero avec
+#  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+#  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+#                                       <http://www.gnu.org/licenses/>.
+#
+#
+# ***********************************************************************
+import logging
+import astropy.table
+from astroquery.cadc import Cadc
+import re
+import io
+from cadcutils import net
+from cadcdata import CadcDataClient
+
+
+class Finder:
+    """
+    Finds all data for a given NIRI stack.
+    """
+
+    def __init__(self, state):
+        self.state = state
+        self.logger = logging.getLogger('niriPipe.utils.finder')
+        try:
+            self._log_basic_constraints()
+        except KeyError as e:
+            logging.critical(
+                "Insufficient constraints provided; " +
+                "is the config file complete?")
+            raise e
+
+    def run(self):
+        """
+        Runs the datafinder.
+
+        self._find_objects() gets object frames based on information in
+        self.state, and gets additional metadata from those object frames
+        about the current stack (things like integration time, filter, etc.)
+        This metadata (encoded in self.state) is then used to find appropriate
+        calibrations. NIRI needs flat field frames, long darks (darks with
+        the same integration time as science frames), and optional short darks
+        (1 second darks used to generate a bad pixel mask).
+        """
+        return astropy.table.vstack([
+            self._find_objects(),
+            self._segment(self._find_flats()),
+            self._segment(self._find_longdarks()),
+            self._segment(self._find_shortdarks())
+        ])
+
+    def _log_basic_constraints(self):
+        """
+        Log constraints that must be provided for the program to work.
+        """
+        self.logger.debug("Stack name: {}".format(
+            self.state['current_stack']['obs_name']))
+
+        self.logger.debug("Min required object frames: {}".format(
+            self.state['config']['DATAFINDER']['min_objects']))
+
+        self.logger.debug("Min required flat frames: {}".format(
+            self.state['config']['DATAFINDER']['min_flats']))
+
+        self.logger.debug("Min required longdark frames: {}".format(
+            self.state['config']['DATAFINDER']['min_longdarks']))
+
+        self.logger.debug("Min required shortdark frames: {}".format(
+            self.state['config']['DATAFINDER']['min_shortdarks']))
+
+    def _find_objects(self):
+        """
+        Find OBJECT frames and set metadata used to find calibrations.
+
+        Should be called before any of the find_cal_* methods.
+        """
+        object_query = \
+            "SELECT publisherID, productID, energy_bandpassName, " + \
+            "time_bounds_lower, time_exposure, type, intent " + \
+            "FROM caom2.Plane AS Plane " + \
+            "JOIN caom2.Observation AS Observation " + \
+            "ON Plane.obsID = Observation.obsID " + \
+            "WHERE Observation.collection = 'GEMINI' " + \
+            "AND Observation.instrument_name = 'NIRI' " + \
+            "AND Plane.dataProductType = 'image' " + \
+            "AND Observation.observationID LIKE '{}%' ".format(
+                self.state['current_stack']['obs_name']
+                )
+
+        object_table = self._find_frames(object_query, 'object')
+
+        # Set state based on the returned table.
+        # Assuming all rows have same filter/exptime/etc,
+        # get information from the first row.
+        # Some metadata isn't available from CADC, so use cadc-data
+        # to get header for file and set it that way.
+        try:
+            self.state['current_stack']['filter'] = \
+                object_table['energy_bandpassName'][0]
+            self.state['current_stack']['exptime'] = \
+                object_table['time_exposure'][0]
+            self.state['current_stack']['mjd_date'] = \
+                (object_table['time_bounds_lower'][0] +
+                    object_table['time_bounds_lower'][0])/2
+            self.state['current_stack']['camera'] = \
+                self._metadata_from_header(
+                    object_table[0]['productID']+'.fits', card='CAMERA')
+        except Exception as e:
+            self.logger.critical("Failed to set stack metadata from objects.")
+            raise e
+
+        return object_table
+
+    def _find_flats(self):
+        """
+        Find flat frames.
+
+        NIRI has three cameras and (I think) we need to make sure the camera
+        used in flats matches the camera used for the object frames.
+        """
+        flat_query = \
+            "SELECT publisherID, productID, energy_bandpassName, " + \
+            "time_bounds_lower, time_exposure, type, intent " + \
+            "FROM caom2.Plane AS Plane " + \
+            "JOIN caom2.Observation AS Observation " + \
+            "ON Plane.obsID = Observation.obsID " + \
+            "WHERE Observation.collection = 'GEMINI' " + \
+            "AND Observation.instrument_name = 'NIRI' " + \
+            "AND Plane.dataProductType = 'image' " + \
+            "AND Observation.type = 'FLAT' " + \
+            "AND Plane.time_bounds_lower >= '{}' ".format(
+                self.state['current_stack']['mjd_date'] - 2) + \
+            "AND Plane.time_bounds_lower <= '{}' ".format(
+                self.state['current_stack']['mjd_date'] + 2) + \
+            "AND Plane.energy_bandpassName = '{}' ".format(
+                self.state['current_stack']['filter'])
+
+        flat_table = self._find_frames(flat_query, 'flat')
+
+        # Exclude flats that don't use same camera as objects
+        self.logger.debug("Adding camera information to flats.")
+        try:
+            cam_column = [self._metadata_from_header(
+                x['productID']+'.fits', 'CAMERA') for x in flat_table]
+            flat_table.add_column(cam_column, name='camera')
+            self.logger.debug("Done getting camera information.")
+            mask = (flat_table['camera'] !=
+                    self.state['current_stack']['camera'])
+            flat_table.remove_rows(mask)
+            self.logger.debug("{} frames remain after matching camera.".format(
+                len(flat_table)))
+        except Exception:
+            self.logger.warning(
+                "Failed to make sure flats had same camera as objects.")
+
+        return flat_table
+
+    def _find_longdarks(self):
+        """
+        Find longdark frames.
+
+        Long darks are darks with the same integration time as object frames.
+        """
+        longdark_query = \
+            "SELECT publisherID, productID, energy_bandpassName, " + \
+            "time_bounds_lower, time_exposure, type, intent " + \
+            "FROM caom2.Plane AS Plane " + \
+            "JOIN caom2.Observation AS Observation " + \
+            "ON Plane.obsID = Observation.obsID " + \
+            "WHERE Observation.collection = 'GEMINI' " + \
+            "AND Observation.instrument_name = 'NIRI' " + \
+            "AND Plane.dataProductType = 'image' " + \
+            "AND Observation.type = 'DARK' " + \
+            "AND Plane.time_bounds_lower >= '{}' ".format(
+                self.state['current_stack']['mjd_date'] - 2) + \
+            "AND Plane.time_bounds_lower <= '{}' ".format(
+                self.state['current_stack']['mjd_date'] + 2) + \
+            "AND Plane.time_exposure = '{}' ".format(
+                self.state['current_stack']['exptime'])
+
+        return self._find_frames(longdark_query, 'longdark')
+
+    def _find_shortdarks(self):
+        """
+        Short darks are optional darks with integration time ~= 1.0s.
+
+        Used to create a "fresh" bad pixel mask.
+        """
+        shortdark_query = \
+            "SELECT publisherID, productID, energy_bandpassName, " + \
+            "time_bounds_lower, time_exposure, type, intent " + \
+            "FROM caom2.Plane AS Plane " + \
+            "JOIN caom2.Observation AS Observation " + \
+            "ON Plane.obsID = Observation.obsID " + \
+            "WHERE Observation.collection = 'GEMINI' " + \
+            "AND Observation.instrument_name = 'NIRI' " + \
+            "AND Plane.dataProductType = 'image' " + \
+            "AND Observation.type = 'DARK' " + \
+            "AND Plane.time_bounds_lower >= '{}' ".format(
+                self.state['current_stack']['mjd_date'] - 2) + \
+            "AND Plane.time_bounds_lower <= '{}' ".format(
+                self.state['current_stack']['mjd_date'] + 2) + \
+            "AND Plane.time_exposure >= '0.99' " + \
+            "AND Plane.time_exposure <= '1.01' "
+
+        return self._find_frames(shortdark_query, 'shortdark')
+
+    def _find_frames(self, query, frame_type):
+        """
+        Do the heavy lifting of finding frames from CADC.
+
+        Tries to find more than "min_objects", "min_flats", etc. of
+        each type of frame. Either returns a table (possibly empty)
+        when appropriate, or raises an exception if insufficient files
+        found.
+        """
+        self.logger.debug("Finding {} frames.".format(frame_type))
+        key = 'min_{}s'.format(frame_type)
+        try:
+            table = self._do_query(query)
+        except Exception as e:
+            if self.state['config']['DATAFINDER'][key]:
+                logging.critical("{} query failed.".format(frame_type))
+                raise e
+            else:
+                self.logger.debug("Found no frames; returning empty table.")
+                return astropy.table.Table(names=('publisherID', 'productID'))
+
+        if len(table) < \
+                self.state['config']['DATAFINDER'][key]:
+            raise RuntimeError("Required {} {} frames; found {}.".format(
+                self.state['config']['DATAFINDER'][key],
+                frame_type,
+                len(table)))
+        self.logger.debug("Found {} {} frames.".format(len(table), frame_type))
+        return table
+
+    def _do_query(self, query):  # pragma: no cover
+        """
+        Does a CADC async query.
+        """
+        cadc = Cadc()
+        job = cadc.create_async(query)
+        job.run().wait()
+        job.raise_if_error()
+        return job.fetch_result().to_table()
+
+    def _metadata_from_header(self, productID, card):  # pragma: no cover
+        """
+        Use cadc-data to get metadata not findable by tap.
+
+        This method is a hack to get around metadata not available in CADC TAP.
+        The better solution is to get all metadata possible from CADC TAP.
+        There are probably better ways to do this, but the intention is to
+        minimize the use of this method.
+        """
+        anonSubject = net.Subject()
+        client = CadcDataClient(anonSubject)
+        with io.BytesIO() as f:
+            f.name = None
+            client.get_file('GEM', productID, f, fhead=True)
+            contents = f.getvalue().decode('utf-8')
+            if card == 'CAMERA':
+                pattern = re.compile(r'(?<=CAMERA  \= \')[^\s]*')
+                return pattern.search(contents).group()
+            else:
+                raise ValueError("Card {} not implemented.".format(card))
+
+    def _segment(self, in_table):
+        """
+        Narrow a table down to the single observation closest to the object
+        observation in time.
+
+        First, compute an observation name column for the table. Then, for
+        each observation name, calculate the time difference between it
+        and the object frames (use an average here of the first and last
+        frames in the observation). Return the frames of that closest
+        observation.
+
+        The failure of segmentation might cause downstream errors, so log
+        a warning if it fails.
+        """
+        self.logger.debug(
+            "Segmentation starting with {} frames.".format(len(in_table)))
+        # Do segmentation based on state['current_stack']['mjd+date']
+        in_table.sort(['publisherID'])
+
+        # Make a new column with the observation name
+        # Test strings:
+        #  ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/N20190404S0013
+        # ivo://cadc.nrc.ca/GEMINI?GN-2019A-FT-108-12-010/N20190405S0120
+        #   ivo://cadc.nrc.ca/GEMINI?GN-CAL20190406-8-004/N20190406S0115
+        # Results:
+        # GN-CAL20190404-10, GN-2019A-FT-108, GN-CAL20190406-8
+        pattern = re.compile(
+            r'(?<=\?)(?:[^-]*-CAL[^-]*-[^-]*|[^-]*-[^-]*-[^-]*-[^-]*)')
+
+        new_column = []
+        for item in in_table['publisherID']:
+            try:
+                tmp = pattern.search(item).group()
+            except TypeError:  # pragma: no cover
+                tmp = pattern.search(item.decode('utf-8')).group()
+            except AttributeError:
+                self.logger.warning(
+                    "Unable to parse publisherID {}; ".format(item) +
+                    "quiting segmentation.")
+                return in_table
+            new_column.append(tmp)
+
+        new_table = astropy.table.Table([
+            new_column,
+            in_table['time_bounds_lower']],
+            names=['observation_name', 'time_bounds_lower']
+        )
+
+        closest_obs_name = None
+        closest_time = float('inf')
+        for obs_name in set(new_table['observation_name']):
+            mask = (new_table['observation_name'] == obs_name)
+            time_obs = (max(new_table[mask]['time_bounds_lower']) +
+                        min(new_table[mask]['time_bounds_lower'])) / 2
+            delta = abs(time_obs - self.state['current_stack']['mjd_date'])
+            if delta < closest_time:
+                closest_obs_name = obs_name
+                closest_time = delta
+
+        if not closest_obs_name:
+            self.logger.warning("Segmentation failed.")
+            return in_table
+
+        mask = (new_table['observation_name'] == closest_obs_name)
+        out_table = in_table[mask]
+
+        self.logger.debug(
+            "Segmentation finished with {} frames.".format(len(out_table)))
+        return out_table

--- a/niriPipe/utils/tests/test_finder.py
+++ b/niriPipe/utils/tests/test_finder.py
@@ -1,0 +1,318 @@
+# -*- coding: utf-8 -*-
+# ***********************************************************************
+# ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
+# *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
+#
+#  (c) 2021.                            (c) 2021.
+#  Government of Canada                 Gouvernement du Canada
+#  National Research Council            Conseil national de recherches
+#  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
+#  All rights reserved                  Tous droits réservés
+#
+#  NRC disclaims any warranties,        Le CNRC dénie toute garantie
+#  expressed, implied, or               énoncée, implicite ou légale,
+#  statutory, of any kind with          de quelque nature que ce
+#  respect to the software,             soit, concernant le logiciel,
+#  including without limitation         y compris sans restriction
+#  any warranty of merchantability      toute garantie de valeur
+#  or fitness for a particular          marchande ou de pertinence
+#  purpose. NRC shall not be            pour un usage particulier.
+#  liable in any event for any          Le CNRC ne pourra en aucun cas
+#  damages, whether direct or           être tenu responsable de tout
+#  indirect, special or general,        dommage, direct ou indirect,
+#  consequential or incidental,         particulier ou général,
+#  arising from the use of the          accessoire ou fortuit, résultant
+#  software.  Neither the name          de l'utilisation du logiciel. Ni
+#  of the National Research             le nom du Conseil National de
+#  Council of Canada nor the            Recherches du Canada ni les noms
+#  names of its contributors may        de ses  participants ne peuvent
+#  be used to endorse or promote        être utilisés pour approuver ou
+#  products derived from this           promouvoir les produits dérivés
+#  software without specific prior      de ce logiciel sans autorisation
+#  written permission.                  préalable et particulière
+#                                       par écrit.
+#
+#  This file is part of the             Ce fichier fait partie du projet
+#  OpenCADC project.                    OpenCADC.
+#
+#  OpenCADC is free software:           OpenCADC est un logiciel libre ;
+#  you can redistribute it and/or       vous pouvez le redistribuer ou le
+#  modify it under the terms of         modifier suivant les termes de
+#  the GNU Affero General Public        la “GNU Affero General Public
+#  License as published by the          License” telle que publiée
+#  Free Software Foundation,            par la Free Software Foundation
+#  either version 3 of the              : soit la version 3 de cette
+#  License, or (at your option)         licence, soit (à votre gré)
+#  any later version.                   toute version ultérieure.
+#
+#  OpenCADC is distributed in the       OpenCADC est distribué
+#  hope that it will be useful,         dans l’espoir qu’il vous
+#  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
+#  without even the implied             GARANTIE : sans même la garantie
+#  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
+#  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+#  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
+#  General Public License for           Générale Publique GNU Affero
+#  more details.                        pour plus de détails.
+#
+#  You should have received             Vous devriez avoir reçu une
+#  a copy of the GNU Affero             copie de la Licence Générale
+#  General Public License along         Publique GNU Affero avec
+#  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+#  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
+#                                       <http://www.gnu.org/licenses/>.
+#
+#
+# ***********************************************************************
+
+import unittest
+from unittest.mock import patch
+import pytest
+import astropy.table
+import os
+import logging
+from niriPipe.utils.finder import Finder
+
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+TESTDATA_DIR = os.path.join(THIS_DIR, 'data')
+
+
+def raise_exception():
+    """
+    Raises an exception.
+    """
+    raise Exception()
+
+
+def get_state(
+        min_objects=1,
+        min_flats=1,
+        min_longdarks=1,
+        min_shortdarks=1,
+        stack_metadata=None
+        ):
+    """
+    Return appliation state dictionary.
+    """
+
+    state = {
+            'config': {
+                'DATAFINDER': {
+                    'min_objects': min_objects,
+                    'min_flats': min_flats,
+                    'min_longdarks': min_longdarks,
+                    'min_shortdarks': min_shortdarks
+                }
+            },
+            'current_stack': {
+                'obs_name': 'GN-XXXXX-X-X-X'
+            }
+    }
+
+    if stack_metadata:
+        for key, value in stack_metadata.items():
+            state['current_stack'][key] = value
+
+    return state
+
+
+class TestFinder(unittest.TestCase):
+    """
+    Test the Finder class.
+    """
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir):
+        tmpdir.chdir()
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        """
+        Magic to get log capturing working.
+        """
+        self._caplog = caplog
+
+    def test_init(self):
+        """
+        Make sure insufficient state is caught
+        """
+        state = {}
+        with pytest.raises(KeyError):
+            Finder(state)
+
+    @patch.object(Finder, '_do_query', side_effect=[
+            astropy.table.Table(
+                [
+                    ['object'],
+                    ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
+                        'N20_object_00'],
+                    [1.0],
+                    ['J'],
+                    [58000.01]],
+                names=[
+                    'productID', 'publisherID', 'time_exposure',
+                    'energy_bandpassName', 'time_bounds_lower']),
+            astropy.table.Table(
+                [
+                    ['flat1', 'flat2'],
+                    ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
+                        'N20_flat_00',
+                        'ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-12-013/' +
+                        'N20_flat_01'],
+                    [58000.02, 58000.01],
+                ],
+                names=['productID', 'publisherID', 'time_bounds_lower']),
+            astropy.table.Table(
+                [
+                    ['longdark'],
+                    ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
+                        'N20_longdark_00'],
+                    [58000.01],
+                ],
+                names=['productID', 'publisherID', 'time_bounds_lower']),
+            astropy.table.Table(
+                [
+                    ['shortdark'],
+                    ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
+                        'N20_shortdark_00'],
+                    [58000.01],
+                ],
+                names=['productID', 'publisherID', 'time_bounds_lower']),
+        ])
+    @patch.object(Finder, '_metadata_from_header',
+                  return_value='f6')
+    def test_run_flawless(self, mock1, mock2):
+        """
+        Perfect run that returns the minimum number of required files.
+
+        _do_query() will be called:
+            - First for objects
+            - Second for flats
+            - Third for longdarks
+            - Fourth for shortdarks
+        """
+        self._caplog.clear()
+
+        state = get_state()
+
+        with self._caplog.at_level(logging.DEBUG):
+            finder = Finder(state)
+            finder.run()
+
+        assert 'object' in self._caplog.text
+        assert 'flat' in self._caplog.text
+        assert 'longdark' in self._caplog.text
+        assert 'shortdark' in self._caplog.text
+
+    @patch.object(Finder, '_find_frames', return_value=None)
+    def test_find_objects(self, mock):
+        """
+        Catch possible failures in _find_objects.
+        """
+        self._caplog.clear()
+
+        state = get_state()
+
+        finder = Finder(state)
+        with self._caplog.at_level(logging.CRITICAL):
+            with pytest.raises(Exception):
+                finder._find_objects()
+        assert 'Failed to set stack metadata' in self._caplog.text
+
+    @patch.object(Finder, '_find_frames', return_value=None)
+    def test_find_flats(self, mock):
+        """
+        Make sure flats are comparing camera information.
+        """
+        self._caplog.clear()
+
+        state = get_state(stack_metadata={'mjd_date': 10000, 'filter': 'J'})
+
+        finder = Finder(state)
+        with self._caplog.at_level(logging.WARNING):
+            finder._find_flats()
+        assert 'Failed to make sure' in self._caplog.text
+
+    def test_find_frames(self):
+        """
+        Catch various failure modes in _find_frames.
+        """
+        self._caplog.clear()
+
+        # If CADC TAP raises exception for required frames, raise error.
+        state = get_state()
+
+        with self._caplog.at_level(logging.CRITICAL):
+            with patch.object(Finder, '_do_query', raise_exception):
+                finder = Finder(state)
+                with pytest.raises(Exception):
+                    finder._find_frames('fake_query', 'object')
+        assert 'object query failed' in self._caplog.text
+
+        # However, if TAP raises exception for optional frames, shouldn't
+        # raise an error.
+        state = get_state(min_objects=0)
+
+        with self._caplog.at_level(logging.DEBUG):
+            with patch.object(Finder, '_do_query', raise_exception):
+                finder = Finder(state)
+                finder._find_frames('fake_query', 'object')
+        assert 'Found no frames; returning empty' in self._caplog.text
+
+        # If TAP returns less frames than required, raise an exception.
+        state = get_state(min_objects=3)
+
+        with patch.object(
+                Finder, '_do_query', return_value=['1.fits', '2.fits']):
+            finder = Finder(state)
+            with pytest.raises(RuntimeError) as exc_info:
+                finder._find_frames('fake_query', 'object')
+        assert 'Required 3 object' in str(exc_info.value)
+
+    def test_segmentation(self):
+        """
+        Make sure only frames of the closest observation in time to the
+        object frames are returned.
+        """
+
+        # Empty input table should just return input table
+        state = get_state()
+
+        empty_table = astropy.table.Table(
+            [[], [], []],
+            names=['productID', 'publisherID', 'time_bounds_lower'])
+
+        self._caplog.clear()
+        with self._caplog.at_level(logging.WARNING):
+            finder = Finder(state)
+        assert len(finder._segment(empty_table)) == 0
+        assert 'Segmentation failed.' in self._caplog.text
+
+        # A one-row table should just be returned
+        state = get_state(stack_metadata={'mjd_date': 57000})
+
+        one_row_table = astropy.table.Table([
+            ['foo'],
+            ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/N20_shortdark'],
+            [58000]],
+            names=['productID', 'publisherID', 'time_bounds_lower'])
+
+        finder = Finder(state)
+        assert len(finder._segment(one_row_table)) == 1
+
+        # We need to compute an observation name column to do segmentation.
+        # If that fails, log a warning because this might break downstream
+        # processing.
+        state = get_state(stack_metadata={'mjd_date': 57000})
+
+        bad_one_row_table = astropy.table.Table([
+            ['foo'],
+            ['ivo://bad_publisher_id'],
+            [58000]],
+            names=['productID', 'publisherID', 'time_bounds_lower'])
+
+        finder = Finder(state)
+        self._caplog.clear()
+        with self._caplog.at_level(logging.WARNING):
+            finder = Finder(state)
+        assert len(finder._segment(bad_one_row_table)) == 1
+        assert 'Unable to parse publisherID' in self._caplog.text

--- a/niriPipe/utils/tests/test_finder.py
+++ b/niriPipe/utils/tests/test_finder.py
@@ -145,12 +145,14 @@ class TestFinder(unittest.TestCase):
                     ['object'],
                     ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
                         'N20_object_00'],
+                    ['GN-CAL20190404-10-013'],
                     [1.0],
                     ['J'],
                     [58000.01]],
                 names=[
-                    'productID', 'publisherID', 'time_exposure',
-                    'energy_bandpassName', 'time_bounds_lower']),
+                    'productID', 'publisherID', 'observationID',
+                    'time_exposure', 'energy_bandpassName',
+                    'time_bounds_lower']),
             astropy.table.Table(
                 [
                     ['flat1', 'flat2'],
@@ -158,25 +160,34 @@ class TestFinder(unittest.TestCase):
                         'N20_flat_00',
                         'ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-12-013/' +
                         'N20_flat_01'],
+                    ['GN-CAL20190404-10-013', 'GN-CAL20190404-12-013'],
                     [58000.02, 58000.01],
                 ],
-                names=['productID', 'publisherID', 'time_bounds_lower']),
+                names=[
+                    'productID', 'publisherID', 'observationID',
+                    'time_bounds_lower']),
             astropy.table.Table(
                 [
                     ['longdark'],
                     ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
                         'N20_longdark_00'],
+                    ['GN-CAL20190404-12-013'],
                     [58000.01],
                 ],
-                names=['productID', 'publisherID', 'time_bounds_lower']),
+                names=[
+                    'productID', 'publisherID', 'observationID',
+                    'time_bounds_lower']),
             astropy.table.Table(
                 [
                     ['shortdark'],
                     ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/' +
                         'N20_shortdark_00'],
+                    ['GN-CAL20190404-12-013'],
                     [58000.01],
                 ],
-                names=['productID', 'publisherID', 'time_bounds_lower']),
+                names=[
+                    'productID', 'publisherID', 'observationID',
+                    'time_bounds_lower']),
         ])
     @patch.object(Finder, '_metadata_from_header',
                   return_value='f6')
@@ -278,8 +289,9 @@ class TestFinder(unittest.TestCase):
         state = get_state()
 
         empty_table = astropy.table.Table(
-            [[], [], []],
-            names=['productID', 'publisherID', 'time_bounds_lower'])
+            [[], [], [], []],
+            names=['productID', 'publisherID', 'observationID',
+                   'time_bounds_lower'])
 
         self._caplog.clear()
         with self._caplog.at_level(logging.WARNING):
@@ -293,8 +305,10 @@ class TestFinder(unittest.TestCase):
         one_row_table = astropy.table.Table([
             ['foo'],
             ['ivo://cadc.nrc.ca/GEMINI?GN-CAL20190404-10-013/N20_shortdark'],
+            ['GN-CAL20190404-10-013'],
             [58000]],
-            names=['productID', 'publisherID', 'time_bounds_lower'])
+            names=['productID', 'publisherID', 'observationID',
+                   'time_bounds_lower'])
 
         finder = Finder(state)
         assert len(finder._segment(one_row_table)) == 1
@@ -307,12 +321,14 @@ class TestFinder(unittest.TestCase):
         bad_one_row_table = astropy.table.Table([
             ['foo'],
             ['ivo://bad_publisher_id'],
+            ['GN-FOO'],
             [58000]],
-            names=['productID', 'publisherID', 'time_bounds_lower'])
+            names=['productID', 'publisherID', 'observationID',
+                   'time_bounds_lower'])
 
         finder = Finder(state)
         self._caplog.clear()
         with self._caplog.at_level(logging.WARNING):
             finder = Finder(state)
         assert len(finder._segment(bad_one_row_table)) == 1
-        assert 'Unable to parse publisherID' in self._caplog.text
+        assert 'Unable to parse observationID' in self._caplog.text

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,9 @@ packages = find:
 install_requires =
 	requests
 	pyvo
+	cadcutils
+	cadcdata
+	astropy >= 4.0
 
 [options.package_data]
 * = *.cfg


### PR DESCRIPTION
This PR adds the NIRI data finder with associated unit and integration tests.

The datafinder uses CADC TAP and `cadc-data` to generate a table of files to download. It *should* return a table with sufficient publisherIDs, or raise an exception if insufficient files found. It should also log a warning if it returns more than the minimum necessary amount of files (IE, more than one sequence of flats, darks, etc.).